### PR TITLE
Silence cmake 3.20.5 policy warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
-if (POLICY CMP0074)
-  cmake_policy(SET CMP0074 OLD)
-endif()
+cmake_minimum_required(VERSION 3.12)
 project(sensei)
 
 include(CMakeDependentOption)


### PR DESCRIPTION
This silences the CMP0074 policy warning thrown during configuration by CMake 3.20.5. 

Fixes https://github.com/SENSEI-insitu/SENSEI/issues/22