### PR TITLE
Tests: Point to target file not target name

### DIFF
--- a/miniapps/mandelbrot/testing/CMakeLists.txt
+++ b/miniapps/mandelbrot/testing/CMakeLists.txt
@@ -1,22 +1,22 @@
 if (BUILD_TESTING)
 
   senseiAddTest(testMandelbrotHistogram
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_histogram.xml)
 
   senseiAddTest(testMandelbrotHistogramPar
     PARALLEL ${TEST_NP}
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_histogram.xml)
 
   senseiAddTest(testMandelbrotVTKWriter
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_vtkwriter.xml
     FEATURES VTK_IO VTK_MPI)
 
   senseiAddTest(testMandelbrotVTKWriterPar
     PARALLEL ${TEST_NP}
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_vtkwriter.xml
     FEATURES VTK_IO VTK_MPI)
 
@@ -27,13 +27,13 @@ if (BUILD_TESTING)
 
   senseiAddTest(testMandelbrotCatalyst
     COMMAND
-      mandelbrot -i 2 -l 2
+      $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_catalyst.xml
     FEATURES CATALYST)
 
   senseiAddTest(testMandelbrotCatalystPar
     PARALLEL ${TEST_NP}
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_catalyst.xml
       FEATURES CATALYST)
 
@@ -43,13 +43,13 @@ if (BUILD_TESTING)
   endif()
 
   senseiAddTest(testMandelbrotLibsim
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_libsim.xml
     FEATURES LIBSIM)
 
   senseiAddTest(testMandelbrotLibsimPar
     PARALLEL ${TEST_NP}
-    COMMAND mandelbrot -i 2 -l 2
+    COMMAND $<TARGET_FILE:mandelbrot> -i 2 -l 2
       -f ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_libsim.xml
     FEATURES LIBSIM)
 

--- a/miniapps/oscillators/testing/CMakeLists.txt
+++ b/miniapps/oscillators/testing/CMakeLists.txt
@@ -1,36 +1,36 @@
 if (BUILD_TESTING)
 
   senseiAddTest(testOscillatorHistogram
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_histogram.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc)
 
   senseiAddTest(testOscillatorHistogramPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_histogram.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc)
 
   senseiAddTest(testOscillatorAutocorrelation
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_autocorrelation.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc)
 
   senseiAddTest(testOscillatorAutocorrelationPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_autocorrelation.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc)
 
   senseiAddTest(testOscillatorVTKWriter
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_vtkwriter.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES VTK_IO)
 
   senseiAddTest(testOscillatorVTKWriterPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_vtkwriter.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES VTK_IO)
@@ -41,14 +41,14 @@ if (BUILD_TESTING)
   endif()
 
   senseiAddTest(testOscillatorCatalyst
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_catalyst.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES CATALYST)
 
   senseiAddTest(testOscillatorCatalystPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_catalyst.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES CATALYST)
@@ -59,14 +59,14 @@ if (BUILD_TESTING)
   endif()
 
   senseiAddTest(testOscillatorLibsim
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_libsim.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES LIBSIM)
 
   senseiAddTest(testOscillatorLibsimPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 1 -b ${TEST_NP} -g 1
+    COMMAND $<TARGET_FILE:oscillator> -t 1 -b ${TEST_NP} -g 1
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_libsim.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/simple.osc
     FEATURES LIBSIM)
@@ -77,14 +77,14 @@ if (BUILD_TESTING)
   endif()
 
   senseiAddTest(testOscillatorAscent
-    COMMAND oscillator -t 2 -b ${TEST_NP} -g 0
+    COMMAND $<TARGET_FILE:oscillator> -t 2 -b ${TEST_NP} -g 0
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_ascent.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/random_2d_64.osc
     FEATURES ASCENT)
 
   senseiAddTest(testOscillatorAscentPar
     PARALLEL ${TEST_NP}
-    COMMAND oscillator -t 2 -b ${TEST_NP} -g 0
+    COMMAND $<TARGET_FILE:oscillator> -t 2 -b ${TEST_NP} -g 0
       -f ${CMAKE_CURRENT_SOURCE_DIR}/oscillator_ascent.xml
       ${CMAKE_CURRENT_SOURCE_DIR}/random_2d_64.osc
     FEATURES ASCENT)
@@ -93,7 +93,7 @@ if (BUILD_TESTING)
   #if (ENABLE_CATALYST)
   #  add_test(NAME testCatalystSlice
   #    COMMAND ${CMAKE_COMMAND}
-  #     -DCATALYST_TEST_DRIVER:FILEPATH=$<TARGET_FILE:oscillator>
+  #     -DCATALYST_TEST_DRIVER:FILEPATH=$<TARGET_FILE:$<TARGET_FILE:oscillator>>
   #    -DIMAGE_TESTER:FILEPATH=$<TARGET_FILE:CompareImages>
   #    -DCATALYST_TEST_DIR:PATH=${CMAKE_BINARY_DIR}/Testing
   #    -DCATALYST_TEST_DATA=${CMAKE_CURRENT_SOURCE_DIR}

--- a/sensei/testing/CMakeLists.txt
+++ b/sensei/testing/CMakeLists.txt
@@ -3,12 +3,12 @@ if (BUILD_TESTING)
   ##############################################################################
   senseiAddTest(testHistogramSerial
     SOURCES testHistogram.cpp LIBS sensei EXEC_NAME testHistogram
-    COMMAND $<TARGET_NAME:testHistogram>
+    COMMAND $<TARGET_FILE:testHistogram>
     LABELS HISTO)
 
   senseiAddTest(testHistogramParallel
     PARALLEL ${TEST_NP}
-    COMMAND $<TARGET_NAME:testHistogram>
+    COMMAND $<TARGET_FILE:testHistogram>
     PROPERTIES
       LABELS HISTO)
 
@@ -16,12 +16,12 @@ if (BUILD_TESTING)
   senseiAddTest(testHDF5Write
     SOURCES testHDF5.cpp LIBS sensei EXEC_NAME testHDF5
     PARALLEL ${TEST_NP}
-    COMMAND $<TARGET_NAME:testHDF5> w 4 n h5test
+    COMMAND $<TARGET_FILE:testHDF5> w 4 n h5test
     FEATURES HDF5)
 
   senseiAddTest(testHDF5Read
     PARALLEL ${TEST_NP}
-    COMMAND $<TARGET_NAME:testHDF5> r h5test.n${TEST_NP}
+    COMMAND $<TARGET_FILE:testHDF5> r h5test.n${TEST_NP}
     FEATURES HDF5
     PROPERTIES
       DEPENDS testHDF5Write)
@@ -29,14 +29,14 @@ if (BUILD_TESTING)
   ##############################################################################
   senseiAddTest(testHDF5WriteStreaming
     PARALLEL ${TEST_NP}
-    COMMAND $<TARGET_NAME:testHDF5> w 4 s h5stream
+    COMMAND $<TARGET_FILE:testHDF5> w 4 s h5stream
     FEATURES HDF5
     PROPERTIES
       LABELS STREAMING)
 
   senseiAddTest(testHDF5ReadStreaming
     PARALLEL ${TEST_NP}
-    COMMAND $<TARGET_NAME:testHDF5> r h5stream.n${TEST_NP} s
+    COMMAND $<TARGET_FILE:testHDF5> r h5stream.n${TEST_NP} s
     FEATURES HDF5
     PROPERTIES
       DEPENDS testHDF5WriteStreaming
@@ -45,7 +45,7 @@ if (BUILD_TESTING)
   ##############################################################################
   senseiAddTest(testProgrammableDataAdaptor
     PARALLEL 1
-    COMMAND $<TARGET_NAME:testProgrammableDataAdaptor>
+    COMMAND $<TARGET_FILE:testProgrammableDataAdaptor>
     SOURCES testProgrammableDataAdaptor.cpp
     LIBS sensei)
 
@@ -59,13 +59,13 @@ if (BUILD_TESTING)
   senseiAddTest(testPythonAnalysis
     SOURCES testPythonAnalysis.cpp LIBS sensei EXEC_NAME testPythonAnalysis
     COMMAND
-      $<TARGET_NAME:testPythonAnalysis> ${CMAKE_CURRENT_SOURCE_DIR}/testPythonAnalysis.xml
+      $<TARGET_FILE:testPythonAnalysis> ${CMAKE_CURRENT_SOURCE_DIR}/testPythonAnalysis.xml
     FEATURES PYTHON VTK_IO)
 
   senseiAddTest(testPythonAnalysisParallel
     PARALLEL ${TEST_NP}
     COMMAND
-      $<TARGET_NAME:testPythonAnalysis> ${CMAKE_CURRENT_SOURCE_DIR}/testPythonAnalysis.xml
+      $<TARGET_FILE:testPythonAnalysis> ${CMAKE_CURRENT_SOURCE_DIR}/testPythonAnalysis.xml
     FEATURES PYTHON VTK_IO)
 
   ##############################################################################


### PR DESCRIPTION
Test commands were pointing to the target name so
the test command was not always able to find the test
executable causing some tests to fail.