### PR TITLE
Added frequency attribute to ADIOS2, Catalyst, and VTKPosthocIO Analysis Adaptors

### DIFF
--- a/sensei/ADIOS2AnalysisAdaptor.cxx
+++ b/sensei/ADIOS2AnalysisAdaptor.cxx
@@ -179,8 +179,21 @@ int ADIOS2AnalysisAdaptor::FetchFromProducer(
 }
 
 //----------------------------------------------------------------------------
+int ADIOS2AnalysisAdaptor::SetFrequency(unsigned int frequency) 
+{
+  this->Frequency = frequency;
+}
+
+//----------------------------------------------------------------------------
 bool ADIOS2AnalysisAdaptor::Execute(DataAdaptor* dataAdaptor)
 {
+  long step = dataAdaptor->GetDataTimeStep();
+
+  if(this->Frequency > 0 && step % this->Frequency != 0)
+    {
+    return true;
+    }
+
   TimeEvent<128> mark("ADIOS2AnalysisAdaptor::Execute");
 
   // if no dataAdaptor requirements are given, push all the data

--- a/sensei/ADIOS2AnalysisAdaptor.h
+++ b/sensei/ADIOS2AnalysisAdaptor.h
@@ -74,6 +74,9 @@ public:
   /// if none are given then all data is pushed.
   int SetDataRequirements(const DataRequirements &reqs);
 
+  /// Control the frequency of the ADIOS2 Adaptor
+  int SetFrequency(unsigned int frequency);
+
   int AddDataRequirement(const std::string &meshName,
     int association, const std::vector<std::string> &arrays);
 
@@ -119,6 +122,7 @@ protected:
   long StepsPerFile;
   long StepIndex;
   long FileIndex;
+  unsigned int Frequency;
 
 private:
   ADIOS2AnalysisAdaptor(const ADIOS2AnalysisAdaptor&) = delete;

--- a/sensei/CatalystAnalysisAdaptor.cxx
+++ b/sensei/CatalystAnalysisAdaptor.cxx
@@ -236,8 +236,22 @@ int CatalystAnalysisAdaptor::SetWholeExtent(vtkDataObject *dobj,
 }
 
 //----------------------------------------------------------------------------
+int CatalystAnalysisAdaptor::SetFrequency(unsigned int frequency)
+{
+  this->Frequency = frequency;
+  return 0;
+}
+
+
+//----------------------------------------------------------------------------
 bool CatalystAnalysisAdaptor::Execute(DataAdaptor* dataAdaptor)
 {
+  long step = dataAdaptor->GetDataTimeStep();
+
+  if(this->Frequency > 0 && step % this->Frequency != 0)
+    {
+    return true;
+    }
   TimeEvent<128> mark("CatalystAnalysisAdaptor::Execute");
 
   // Get a description of the simulation metadata

--- a/sensei/CatalystAnalysisAdaptor.h
+++ b/sensei/CatalystAnalysisAdaptor.h
@@ -34,6 +34,9 @@ public:
   /// Adds a pipeline initialized from a Catalyst python script
   virtual void AddPythonScriptPipeline(const std::string &fileName);
 
+  /// Control the frequency of the Catalyst python script
+  int SetFrequency(unsigned int frequency);
+
   bool Execute(DataAdaptor* data) override;
 
   int Finalize() override;
@@ -55,6 +58,8 @@ protected:
 private:
   CatalystAnalysisAdaptor(const CatalystAnalysisAdaptor&); // Not implemented.
   void operator=(const CatalystAnalysisAdaptor&); // Not implemented.
+
+  unsigned int Frequency;
 };
 
 }

--- a/sensei/ConfigurableAnalysis.cxx
+++ b/sensei/ConfigurableAnalysis.cxx
@@ -433,6 +433,9 @@ int ConfigurableAnalysis::InternalsType::AddAdios2(pugi::xml_node node)
     SENSEI_ERROR("Failed to configure the ADIOS2 adaptor from XML")
     return -1;
     }
+  
+  unsigned int frequency = node.attribute("frequency").as_uint(0);
+  this->adiosAdaptor->SetFrequency(frequency);
 
   this->TimeInitialization(adiosAdaptor);
   this->Analyses.push_back(adiosAdaptor.GetPointer());
@@ -647,6 +650,10 @@ int ConfigurableAnalysis::InternalsType::AddCatalyst(pugi::xml_node node)
       std::string fileName = node.attribute("filename").value();
       this->CatalystAdaptor->AddPythonScriptPipeline(fileName);
       }
+    
+    unsigned int frequency = node.attribute("frequency").as_uint(0);
+    this->CatalystAdaptor->SetFrequency(frequency);
+
 #endif
     }
   SENSEI_STATUS("Configured CatalystAnalysisAdaptor "
@@ -859,6 +866,7 @@ int ConfigurableAnalysis::InternalsType::AddPosthocIO(pugi::xml_node node)
   std::string writer = node.attribute("writer").as_string("xml");
   std::string ghostArrayName = node.attribute("ghost_array_name").as_string("");
   int verbose = node.attribute("verbose").as_int(0);
+  unsigned int frequency = node.attribute("frequency").as_uint(0);
 
   auto adaptor = vtkSmartPointer<VTKPosthocIO>::New();
 
@@ -867,6 +875,7 @@ int ConfigurableAnalysis::InternalsType::AddPosthocIO(pugi::xml_node node)
 
   adaptor->SetGhostArrayName(ghostArrayName);
   adaptor->SetVerbose(verbose);
+  adaptor->SetFrequency(frequency);
 
   if (adaptor->SetOutputDir(outputDir) || adaptor->SetMode(mode) ||
     adaptor->SetWriter(writer) || adaptor->SetDataRequirements(req))

--- a/sensei/ConfigurableAnalysis.cxx
+++ b/sensei/ConfigurableAnalysis.cxx
@@ -435,7 +435,7 @@ int ConfigurableAnalysis::InternalsType::AddAdios2(pugi::xml_node node)
     }
   
   unsigned int frequency = node.attribute("frequency").as_uint(0);
-  this->adiosAdaptor->SetFrequency(frequency);
+  adiosAdaptor->SetFrequency(frequency);
 
   this->TimeInitialization(adiosAdaptor);
   this->Analyses.push_back(adiosAdaptor.GetPointer());

--- a/sensei/VTKPosthocIO.cxx
+++ b/sensei/VTKPosthocIO.cxx
@@ -233,6 +233,14 @@ int VTKPosthocIO::SetDataRequirements(const DataRequirements &reqs)
 }
 
 //-----------------------------------------------------------------------------
+int VTKPosthocIO::SetFrequency(unsigned int frequency)
+{
+  this->Frequency = frequency;
+  return 0;
+}
+
+
+//-----------------------------------------------------------------------------
 int VTKPosthocIO::AddDataRequirement(const std::string &meshName,
   int association, const std::vector<std::string> &arrays)
 {
@@ -244,6 +252,13 @@ int VTKPosthocIO::AddDataRequirement(const std::string &meshName,
 //-----------------------------------------------------------------------------
 bool VTKPosthocIO::Execute(DataAdaptor* dataAdaptor)
 {
+  long step = dataAdaptor->GetDataTimeStep();
+
+  if(this->Frequency > 0 && step % this->Frequency != 0) 
+    {
+    return true;
+    }
+
   // see what the simulation is providing
   MeshMetadataFlags flags;
   flags.SetBlockDecomp();

--- a/sensei/VTKPosthocIO.h
+++ b/sensei/VTKPosthocIO.h
@@ -58,7 +58,7 @@ public:
   int AddDataRequirement(const std::string &meshName,
     int association, const std::vector<std::string> &arrays);
 
-  ///
+  /// Control the frequency of the VTKPosthocIO Adaptor
   int SetFrequency(unsigned int frequency);
   // SENSEI API
   bool Execute(DataAdaptor* data) override;

--- a/sensei/VTKPosthocIO.h
+++ b/sensei/VTKPosthocIO.h
@@ -58,6 +58,8 @@ public:
   int AddDataRequirement(const std::string &meshName,
     int association, const std::vector<std::string> &arrays);
 
+  ///
+  int SetFrequency(unsigned int frequency);
   // SENSEI API
   bool Execute(DataAdaptor* data) override;
   int Finalize() override;
@@ -80,6 +82,7 @@ private:
   template<typename T>
   using NameMap = std::map<std::string, T>;
 
+  unsigned int Frequency;
   NameMap<std::vector<double>> Time;
   NameMap<std::vector<long>> TimeStep;
   NameMap<std::vector<MeshMetadataPtr>> Metadata;


### PR DESCRIPTION
By adding frequency, the user can control how often the simulation will execute the Analysis Adaptors without having to modify the code. This way, SENSEI can be called for every timestep, and the Analysis will execute depending on the frequency attribute.