### PR TITLE
fix symbol visibility for build shared libs

### DIFF
--- a/python/senseiPython.i
+++ b/python/senseiPython.i
@@ -24,6 +24,9 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 %}
 
+/* SWIG does not understand attributes */
+#define __attribute__(x)
+
 %init %{
 #if PY_VERSION_HEX < 0x03070000
 PyEval_InitThreads();

--- a/sensei/Calculator.h
+++ b/sensei/Calculator.h
@@ -6,7 +6,7 @@
 namespace sensei
 {
 
-class Calculator : public AnalysisAdaptor
+class SENSEI_EXPORT Calculator : public AnalysisAdaptor
 {
 public:
   static Calculator* New();

--- a/sensei/CatalystParticle.h
+++ b/sensei/CatalystParticle.h
@@ -1,12 +1,14 @@
 #ifndef sensei_CatalystParticle_h
 #define sensei_CatalystParticle_h
 
-#include "vtkCPPipeline.h"
+#include "senseiConfig.h"
+
+#include <vtkCPPipeline.h>
 
 namespace sensei
 {
 
-class CatalystParticle : public vtkCPPipeline
+class SENSEI_EXPORT CatalystParticle : public vtkCPPipeline
 {
 public:
   static CatalystParticle* New();

--- a/sensei/Error.h
+++ b/sensei/Error.h
@@ -8,7 +8,7 @@ namespace sensei
 {
 // detect if we are writing to a tty, if not then
 // we should not use ansi color codes
-int haveTty();
+SENSEI_EXPORT int haveTty();
 
 // a helper class for debug and error
 // messages
@@ -16,9 +16,10 @@ class parallelId {};
 
 // print the callers rank and thread id
 // to the given stream
+SENSEI_EXPORT
 std::ostream &operator<<(std::ostream &os, const parallelId &id);
 
-int ioEnabled(int active_rank);
+SENSEI_EXPORT int ioEnabled(int active_rank);
 }
 
 #define ANSI_RED "\033[1;31m"

--- a/sensei/MeshMetadata.h
+++ b/sensei/MeshMetadata.h
@@ -104,7 +104,7 @@ struct MeshMetadata;
 using MeshMetadataPtr = std::shared_ptr<sensei::MeshMetadata>;
 
 /// A container for capturing metadata describing a mesh.
-struct MeshMetadata
+struct SENSEI_EXPORT MeshMetadata
 {
   /// allocate a new instance
   static

--- a/sensei/XMLUtils.h
+++ b/sensei/XMLUtils.h
@@ -22,18 +22,21 @@ namespace XMLUtils
  * that it does. if not non-zero value is returned and an error message is sent
  * to stderr.
  */
+SENSEI_EXPORT
 int RequireAttribute(const pugi::xml_node &node, const char *attributeName);
 
 /** check that a child element of the passed in name exists return of 0
  * indicates that it does. if not non-zero value is returned and an error
  * message is sent to stderr.
  */
+SENSEI_EXPORT
 int RequireChild(const pugi::xml_node &node, const char *childName);
 
 /** Parallel collective read, parse, and distribute the XML file. Rank 0 does
  * the I/O and parse and will broadcast to the other ranks in the communicator.
  * return of 0 indicates success.
  */
+SENSEI_EXPORT
 int Parse(MPI_Comm comm, const std::string &filename, pugi::xml_document &doc);
 
 

--- a/utils/pysvtk/svtk.i
+++ b/utils/pysvtk/svtk.i
@@ -22,6 +22,9 @@
 #define KWIML_INT_NO_VERIFY
 #define KWIML_ABI_NO_VERIFY
 
+/* SWIG does not understand attributes */
+#define __attribute__(x)
+
 /* automatically convert to the derived type */
 %typemap(out) svtkDataArray*
 {


### PR DESCRIPTION
fix some bugs that popped up when `-DBUILD_SHARED_LIBS=ON`