### PR TITLE
make paraview modules optional to avoid picking up unwanted modules

### DIFF
--- a/CMake/catalyst.cmake
+++ b/CMake/catalyst.cmake
@@ -23,7 +23,7 @@ if (ENABLE_CATALYST)
   else()
     set (SENSEI_PV_COMPONENTS ${sensei_pv_components_5_8})
   endif()
-  find_package(ParaView CONFIG COMPONENTS ${SENSEI_PV_COMPONENTS})
+  find_package(ParaView CONFIG OPTIONAL_COMPONENTS ${SENSEI_PV_COMPONENTS})
 
   # avoid leaking these internal variables
   unset(sensei_pv_components_legacy)


### PR DESCRIPTION
Fixes Issue #37 

Finding the ParaView module RemotingViews was attempting to pull in several unneeded VTK modules that were not being found when ParaView was not configured with them. This is due to how ParaView propagates information about components being optional or not (see [here](https://gitlab.kitware.com/paraview/paraview/-/issues/19538)). Setting components to optional solves the issue and enables  the use of Catalyst 1 with ParaView 5.10. 

Building SENSEI against PV 5.10 seems to fix present issues with the bidirectional Catalyst tests. 