### PR TITLE
oscillator fix a bug in the calculation

### DIFF
--- a/miniapps/oscillators/Oscillator.cpp
+++ b/miniapps/oscillators/Oscillator.cpp
@@ -24,6 +24,15 @@
 namespace
 {
 // **************************************************************************
+const char *name(Oscillator::Type type)
+{
+  if (type == Oscillator::Type::damped) return "damped";
+  else if (type == Oscillator::Type::decaying) return "decaying";
+  else if (type == Oscillator::Type::periodic) return "periodic";
+  return "unknown";
+}
+
+// **************************************************************************
 static inline std::string &ltrim(std::string &s)
 {
     s.erase(s.begin(),
@@ -61,11 +70,24 @@ std::vector<Oscillator> read(const std::string &fn)
         std::string stype;
         iss >> stype;
 
-        auto type = Oscillator::periodic;
+        Oscillator::Type type;
         if (stype == "damped")
+        {
             type = Oscillator::damped;
+        }
         else if (stype == "decaying")
+        {
             type = Oscillator::decaying;
+        }
+        else if (stype == "periodic")
+        {
+            type = Oscillator::periodic;
+        }
+        else
+        {
+            std::cerr << "ERROR: invalid oscillator type \"" << stype << "\"" << std::endl;
+            abort();
+        }
 
         float x,y,z;
         iss >> x >> y >> z;
@@ -229,7 +251,8 @@ void OscillatorArray::Print(std::ostream &os) const
     Oscillator &o = (mData.get())[i];
     os << i << " center = " << o.center_x << ", " << o.center_y << ", "
       << o.center_z << " radius = " << o.radius << " omega0 = "
-      << o.omega0 << " zeta = " << o.zeta << std::endl;
+      << o.omega0 << " zeta = " << o.zeta << " type = " << ::name(o.type)
+      << std::endl;
   }
 }
 

--- a/miniapps/oscillators/Oscillator.h
+++ b/miniapps/oscillators/Oscillator.h
@@ -21,32 +21,36 @@ struct Oscillator
 #endif
     float evaluate(float vx, float vy, float vz, float t) const
     {
-        t *= 2*pi;
+        t *= 2.f*pi;
 
         float dist_x = center_x - vx;
         float dist_y = center_y - vy;
         float dist_z = center_z - vz;
-        float dist2 = sqrt( dist_x*dist_x + dist_y*dist_y + dist_z*dist_z );
-
-        float dist_damp = exp(-dist2/(2*radius*radius));
+        float dist2 = dist_x*dist_x + dist_y*dist_y + dist_z*dist_z;
+        float dist_damp = exp(-dist2/(2.f*radius*radius));
 
         if (type == damped)
         {
             float phi   = acos(zeta);
-            float val   = 1. - exp(-zeta*omega0*t) * (sin(sqrt(1-zeta*zeta)*omega0*t + phi) / sin(phi));
+            float val   = 1.f - exp(-zeta*omega0*t) * (sin(sqrt(1.f-zeta*zeta)*omega0*t + phi) / sin(phi));
             return val * dist_damp;
         }
         else if (type == decaying)
         {
-            t += 1. / omega0;
+            t += 1.f / omega0;
             float val = sin(t / omega0) / (omega0 * t);
             return val * dist_damp;
         }
         else if (type == periodic)
         {
-            t += 1. / omega0;
+            t += 1.f / omega0;
             float val = sin(t / omega0);
             return val * dist_damp;
+        }
+        else
+        {
+            std::cerr << "ERROR: inavid oscillator type" << std::endl;
+            abort();
         }
 
         return 0.0f; // impossible


### PR DESCRIPTION
* reverts to the behavior matching DIY. DIY's norm function was infact
  norm**2. this change reverts the oscillator's field update to use
  norm**2 rather than norm matching the original DIY based
  implementation.
* improves the diagnostics in verbose mode
* aborts if an invalid oscillator type is detected