### PR TITLE
Reignite Computational Steering with Catalyst

### DIFF
--- a/miniapps/oscillators/testing/catalyst-steering/README.md
+++ b/miniapps/oscillators/testing/catalyst-steering/README.md
@@ -1,0 +1,18 @@
+# Computational Steering with Catalyst and SENSEI
+
+## Getting Started
+
+You will need ParaView 5.10 installed, and SENSEI compiled with the options `ENABLE_CATALYST` and `ENABLE_CATALYST_PYTHON` turned on.
+
+Open the ParaView application and navigate to `Tools`->`Manage Plugins`. Press the `Load New...` button, and navigate the file browser to the location of the `oscillator_catalyst_steering_proxies.xml` file, and select that file.
+
+Next, navigate to `Catalyst`->`Connect` and accept incoming connections on port 22222. This will tell ParaView to begin listening for Catalyst connections on that port. If a different port number is desired, you will need to edit the port number in the Catalyst python script `oscillator_catalyst_steering.py` to the desired port, and then start Catalyst in ParaView with the same desired port number.
+
+In a terminal, navigate to your desired run directory (this testing directory is fine to run from), and start the oscillator miniapp with the SENSEI config xml `oscillator_catalyst_steering.xml`. Oscillator miniapp options can be set as desired, but a good starting point is:
+
+```
+mpirun -np 1 /path/to/oscillator -g 1 -t 0.01 -f oscillator_catalyst_steering.xml simple.osc
+```
+With the Oscillator miniapp running, ParaView should automatically detect a new Catalyst connection and add several items to the catalsyt server list in the `Pipeline Browser`. Clicking the icon next to `mesh` and `oscillator` will display the data to the 3D viewport, updating as the miniapp progresses.
+
+Click on the `Steering Parameters` item in the `Pipeline Browser`. The `Properties` panel will display several controls over each oscillator which can be modified, manipulating the oscillator parameters as the miniapp executes.

--- a/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering.py
+++ b/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering.py
@@ -1,0 +1,102 @@
+from paraview.simple import *
+from paraview import coprocessing
+
+
+#--------------------------------------------------------------
+# Code generated from cpstate.py to create the CoProcessor.
+# ParaView 5.4.1 64 bits
+
+#--------------------------------------------------------------
+# Global screenshot output options
+imageFileNamePadding=2
+rescale_lookuptable=False
+
+
+# ----------------------- CoProcessor definition -----------------------
+
+def CreateCoProcessor():
+  def _CreatePipeline(coprocessor, datadescription):
+    class Pipeline:
+      # state file generated using paraview version 5.4.1
+
+      # ----------------------------------------------------------------
+      # setup views used in the visualization
+      # ----------------------------------------------------------------
+
+      #### disable automatic camera reset on 'Show'
+      paraview.simple._DisableFirstRenderCameraReset()
+
+      # ----------------------------------------------------------------
+      # setup the data processing pipelines
+      # ----------------------------------------------------------------
+
+      # create a producer from a simulation input
+      oscillators = coprocessor.CreateProducer(datadescription, 'oscillators')
+      meshpvd = coprocessor.CreateProducer(datadescription, 'mesh')
+
+      # ----------------------------------------------------------------
+      # finally, restore active source
+      SetActiveSource(meshpvd)
+      # ----------------------------------------------------------------
+    return Pipeline()
+
+  class CoProcessor(coprocessing.CoProcessor):
+    def CreatePipeline(self, datadescription):
+      self.Pipeline = _CreatePipeline(self, datadescription)
+
+  coprocessor = CoProcessor()
+  # these are the frequencies at which the coprocessor updates.
+  freqs = {'oscillators': [1], 'mesh': [1]}
+  coprocessor.SetUpdateFrequencies(freqs)
+  return coprocessor
+
+
+#--------------------------------------------------------------
+# Global variable that will hold the pipeline for each timestep
+# Creating the CoProcessor object, doesn't actually create the ParaView pipeline.
+# It will be automatically setup when coprocessor.UpdateProducers() is called the
+# first time.
+coprocessor = CreateCoProcessor()
+
+#--------------------------------------------------------------
+# Enable Live-Visualizaton with ParaView and the update frequency
+coprocessor.EnableLiveVisualization(True, 1)
+
+# ---------------------- Data Selection method ----------------------
+
+def RequestDataDescription(datadescription):
+    "Callback to populate the request for current timestep"
+    global coprocessor
+    if datadescription.GetForceOutput() == True:
+        # We are just going to request all fields and meshes from the simulation
+        # code/adaptor.
+        for i in range(datadescription.GetNumberOfInputDescriptions()):
+            datadescription.GetInputDescription(i).AllFieldsOn()
+            datadescription.GetInputDescription(i).GenerateMeshOn()
+        return
+
+    # setup requests for all inputs based on the requirements of the
+    # pipeline.
+    coprocessor.LoadRequestedData(datadescription)
+
+# ------------------------ Processing method ------------------------
+
+def DoCoProcessing(datadescription):
+    "Callback to do co-processing for current timestep"
+    global coprocessor
+    # Update the coprocessor by providing it the newly generated simulation data.
+    # If the pipeline hasn't been setup yet, this will setup the pipeline.
+    coprocessor.UpdateProducers(datadescription)
+
+    coprocessor.Pipeline.meshpvd.UpdatePipeline(datadescription.GetTime())
+    coprocessor.Pipeline.oscillators.UpdatePipeline(datadescription.GetTime())
+
+    # Write output data, if appropriate.
+    coprocessor.WriteData(datadescription);
+
+    # Write image capture (Last arg: rescale lookup table), if appropriate.
+    coprocessor.WriteImages(datadescription, rescale_lookuptable=rescale_lookuptable,
+        image_quality=0, padding_amount=imageFileNamePadding)
+
+    # Live Visualization, if enabled.
+    coprocessor.DoLiveVisualization(datadescription, "localhost", 22222)

--- a/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering.xml
+++ b/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering.xml
@@ -1,0 +1,7 @@
+<sensei>
+    <analysis type="catalyst" pipeline="pythonscript"
+        filename="oscillator_catalyst_steering.py" enabled="1"
+        plugin_xml="oscillator_catalyst_steering_proxies.xml">
+    <result steerable_source_type="Oscillators" mesh="oscillators" />
+  </analysis>
+</sensei>

--- a/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering_proxies.xml
+++ b/miniapps/oscillators/testing/catalyst-steering/oscillator_catalyst_steering_proxies.xml
@@ -1,0 +1,164 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="sensei_internals">
+    <!-- ==================================================================== -->
+    <Proxy name="OscillatorPrototype" label="Oscillator" >
+      <DoubleVectorProperty name="Center"
+                            number_of_elements="3"
+                            default_values="0 0 0">
+        <DoubleRangeDomain name="range" />
+        <Documentation>
+          Specify center for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <IntVectorProperty name="Type"
+                         number_of_elements="1"
+                         default_values="0">
+        <EnumerationDomain name="enum">
+          <Entry text="damped" value="0" />
+          <Entry text="decaying" value="1" />
+          <Entry text="periodic" value="2" />
+        </EnumerationDomain>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty name="Radius"
+                            number_of_elements="1"
+                            default_values="0">
+        <DoubleRangeDomain name="range"/>
+        <Documentation>
+          Radius for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <DoubleVectorProperty name="Omega0"
+                            number_of_elements="1"
+                            default_values="0">
+        <DoubleRangeDomain name="range"/>
+        <Documentation>
+          Omega0 for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <DoubleVectorProperty name="Zeta"
+                            number_of_elements="1"
+                            default_values="0">
+        <DoubleRangeDomain name="range"/>
+        <Documentation>
+          Zeta for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+    </Proxy>
+  </ProxyGroup>
+
+  <ProxyGroup name="sources">
+    <!-- ==================================================================== -->
+    <SourceProxy class="vtkSteeringDataGenerator" name="Oscillators">
+
+      <IntVectorProperty name="PartitionType"
+                         command="SetPartitionType"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="never">
+        <!-- 0 == VTK_POLY_DATA -->
+      </IntVectorProperty>
+
+      <IntVectorProperty name="FieldAssociation"
+                         command="SetFieldAssociation"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="never">
+        <!-- 0 == Points -->
+      </IntVectorProperty>
+
+      <DoubleVectorProperty name="Center"
+                            command="SetTuple3Double"
+                            use_index="1"
+                            clean_command="Clear"
+                            initial_string="coords"
+                            number_of_elements_per_command="3"
+                            repeat_command="1"
+                            number_of_elements="3"
+                            default_values="1 1 1">
+        <Documentation>
+          Specify center for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <IntVectorProperty name="Type"
+                         command="SetTuple1Int"
+                         clean_command="Clear"
+                         use_index="1"
+                         initial_string="type"
+                         number_of_elements_per_command="1"
+                         repeat_command="1"
+                         number_of_elements="1"
+                         default_values="1">
+        <Documentation>
+          Type of the oscillator.
+        </Documentation>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty name="Radius"
+                            command="SetTuple1Double"
+                            clean_command="Clear"
+                            use_index="1"
+                            initial_string="radius"
+                            number_of_elements_per_command="1"
+                            repeat_command="1"
+                            number_of_elements="1"
+                            default_values="10">
+        <Documentation>
+          Radius for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <DoubleVectorProperty name="Omega0"
+                            command="SetTuple1Double"
+                            clean_command="Clear"
+                            use_index="1"
+                            initial_string="omega0"
+                            number_of_elements_per_command="1"
+                            repeat_command="1"
+                            number_of_elements="1"
+                            default_values="11">
+        <Documentation>
+          Omega0 for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <DoubleVectorProperty name="Zeta"
+                            command="SetTuple1Double"
+                            clean_command="Clear"
+                            use_index="1"
+                            initial_string="zeta"
+                            number_of_elements_per_command="1"
+                            repeat_command="1"
+                            number_of_elements="1"
+                            default_values="12">
+        <DoubleRangeDomain name="range"/>
+        <Documentation>
+          Zeta for the oscillator.
+        </Documentation>
+      </DoubleVectorProperty>
+      <PropertyGroup label="Oscillators" panel_widget="PropertyCollection">
+        <Property name="Center" />
+        <Property name="Type" />
+        <Property name="Omega0" />
+        <Property name="Radius" />
+        <Property name="Zeta" />
+        <Hints>
+          <PropertyCollectionWidgetPrototype group="sensei_internals" name="OscillatorPrototype" />
+        </Hints>
+      </PropertyGroup>
+      <Hints>
+        <SenseiInitializePropertiesWithMesh mesh="oscillators">
+          <Property name="Center" association="point" array="coords" />
+          <Property name="Type"   association="point" array="type" />
+          <Property name="Radius" association="point" array="radius" />
+          <Property name="Omega0" association="point" array="omega0" />
+          <Property name="Zeta"   association="point" array="zeta" />
+        </SenseiInitializePropertiesWithMesh>
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/sensei/CatalystAnalysisAdaptor.cxx
+++ b/sensei/CatalystAnalysisAdaptor.cxx
@@ -14,6 +14,7 @@
 #include <svtkRectilinearGrid.h>
 #include <svtkStructuredGrid.h>
 
+#include <vtkArrayDispatch.h>
 #include <vtkObjectFactory.h>
 #include <vtkDataObject.h>
 #include <vtkAlgorithm.h>
@@ -21,13 +22,22 @@
 #include <vtkCPAdaptorAPI.h>
 #include <vtkCPDataDescription.h>
 #include <vtkCPInputDataDescription.h>
+#include <vtkDataArrayAccessor.h>
+#include <vtkFieldData.h>
+#include <vtkMultiBlockDataSet.h>
 #include <vtkMultiProcessController.h>
 #include <vtkCPProcessor.h>
+#include <vtkPointSet.h>
 #include <vtkPVConfig.h>
+#include <vtkPVXMLElement.h>
 #include <vtkSmartPointer.h>
+#include <vtkSMDoubleVectorProperty.h>
 #include <vtkSMProxyManager.h>
 #include <vtkSMSessionProxyManager.h>
 #include <vtkSMSourceProxy.h>
+#include <vtkSMIdTypeVectorProperty.h>
+#include <vtkSMIntVectorProperty.h>
+#include <vtkSMPluginManager.h>
 #ifdef ENABLE_CATALYST_PYTHON
 #include <vtkCPPythonScriptPipeline.h>
 #endif
@@ -36,8 +46,146 @@
 
 namespace sensei
 {
-
 #ifdef ENABLE_CATALYST_PYTHON
+
+template <typename PropertyType>
+struct PropertyCopier
+{
+  PropertyType* SMProperty = nullptr;
+
+  template <typename ArrayType>
+  void operator()(ArrayType* array)
+  {
+    const vtkIdType numTuples = array->GetNumberOfTuples();
+    const int numComponents = array->GetNumberOfComponents();
+    this->SMProperty->SetNumberOfElements(static_cast<unsigned int>(numTuples*numComponents));
+    vtkDataArrayAccessor<ArrayType> a(array);
+    for (vtkIdType cc=0; cc < numTuples; ++cc)
+      {
+      for (int comp=0; comp < numComponents; ++comp)
+        {
+        this->SMProperty->SetElement(cc*numComponents + comp, a.Get(cc, comp));
+        }
+      }
+  }
+};
+
+template <typename T>
+void SetPropertyValue(T* prop, vtkDataArray* array)
+{
+  PropertyCopier<T> copier;
+  copier.SMProperty = prop;
+  using Dispatcher = vtkArrayDispatch::DispatchByValueType<vtkArrayDispatch::AllTypes>;
+  if (!Dispatcher::Execute(array, copier))
+    {
+    copier(array);
+    }
+}
+
+/// Handles `<SenseiInitializePropertiesWithMesh />` hints on a proxy to
+/// initialize it's properties using data values.
+static bool HandleSenseiInitializePropertiesWithMesh(
+    vtkSMProxy* source, vtkCPDataDescription* dataDescription)
+{
+  if (source == nullptr) { return false; }
+  auto hints = source->GetHints() ?
+    source->GetHints()->FindNestedElementByName("SenseiInitializePropertiesWithMesh") : nullptr;
+  if (!hints) { return true; }
+
+  const char* meshname = hints->GetAttribute("mesh");
+  if (!meshname)
+    {
+    SENSEI_ERROR("`SenseiInitializePropertiesWithMesh` missing 'mesh' attribute.");
+    return false;
+    }
+
+  // initialize properties on the `source` using the mesh data.
+  auto ipDesc = dataDescription->GetInputDescriptionByName(meshname);
+  if (!ipDesc)
+    {
+    SENSEI_ERROR("No mesh named '"<< meshname << "' present.");
+    return false;
+    }
+
+  auto grid = ipDesc->GetGrid();
+  if (auto mb = vtkMultiBlockDataSet::SafeDownCast(grid))
+    {
+    // this may need some rethinking. For now, I am keeping it simply to just use
+    // 1st block in case of vtkMultiBlockDataSet.
+    grid = mb->GetBlock(0);
+    }
+
+  if (!grid)
+    {
+    SENSEI_WARNING("Empty grid received for mesh named '" << meshname << "'.");
+    return true;
+    }
+
+  for (unsigned int cc=0, max=hints->GetNumberOfNestedElements(); cc < max; ++cc)
+    {
+    auto child = hints->GetNestedElement(cc);
+    if (child == nullptr || child->GetName() == nullptr || strcmp(child->GetName(), "Property") != 0)
+      {
+      continue;
+      }
+    if (!child->GetAttribute("name") || !child->GetAttribute("array"))
+      {
+      SENSEI_WARNING("Missing required attribute on `Property` element. Skipping.");
+      continue;
+      }
+
+    auto property = source->GetProperty(child->GetAttribute("name"));
+    if (!property)
+      {
+      SENSEI_WARNING("No property named '" << child->GetAttribute("name") << "' "
+          "present on proxy. Skipping.");
+      continue;
+      }
+
+    int assoc = 0;
+    if (SVTKUtils::GetAssociation(child->GetAttributeOrDefault("association", "point"), assoc))
+      {
+      SENSEI_WARNING("Invalid 'association' specified. Skipping.");
+      continue;
+      }
+    auto arrayname = child->GetAttribute("array");
+    auto fd = grid->GetAttributesAsFieldData(assoc);
+    vtkDataArray* array = fd ? fd->GetArray(arrayname) : nullptr;
+    if (strcmp(arrayname, "coords") == 0 && vtkPointSet::SafeDownCast(grid) &&
+        assoc == vtkDataObject::POINT)
+      {
+      array = vtkPointSet::SafeDownCast(grid)->GetPoints()->GetData();
+      }
+    if (!array)
+      {
+      SENSEI_WARNING("No array named '" << arrayname << "' present. Skipping.");
+      continue;
+      }
+
+    if (array)
+      {
+        if (auto dp = vtkSMDoubleVectorProperty::SafeDownCast(property))
+          {
+          SetPropertyValue<vtkSMDoubleVectorProperty>(dp, array);
+          }
+        else if (auto ip = vtkSMIntVectorProperty::SafeDownCast(property))
+          {
+          SetPropertyValue<vtkSMIntVectorProperty>(ip, array);
+          }
+        else if (auto idp = vtkSMIdTypeVectorProperty::SafeDownCast(property))
+          {
+          SetPropertyValue<vtkSMIdTypeVectorProperty>(idp, array);
+          }
+        else
+        {
+          SENSEI_WARNING("Properties of type '" << property->GetClassName() << "' "
+              "are not supported. Skipping.");
+          continue;
+        }
+      }
+    }
+  return true;
+}
 /// This vtkCPPythonScriptPipeline subclass helps us pass back data
 /// from producer identified in the configuration as result using a
 /// DataAdaptor.
@@ -51,6 +199,12 @@ public:
   /// Get/Set result producer algorithm's registration name.
   vtkSetStringMacro(ResultProducer);
   vtkGetStringMacro(ResultProducer);
+  //@}
+
+  //@{
+  /// Get/Set steerable proxy name.
+  vtkSetStringMacro(SteerableSourceType);
+  vtkGetStringMacro(SteerableSourceType);
   //@}
 
   //@{
@@ -77,17 +231,23 @@ public:
   }
 
 protected:
-  CatalystScriptPipeline() : ResultProducer(nullptr), ResultMesh(nullptr) {}
+  CatalystScriptPipeline() : ResultProducer(nullptr),
+    SteerableSourceType(nullptr), ResultMesh(nullptr) {}
+
   ~CatalystScriptPipeline() override
   {
     this->SetResultProducer(nullptr);
+    this->SetSteerableSourceType(nullptr);
     this->SetResultMesh(nullptr);
   }
 
   int CoProcess(vtkCPDataDescription* dataDescription) override
   {
     this->ResultData = nullptr;
-
+    if (this->SteerableSourceType != nullptr)
+      {
+      this->InitializeSteerableSource(dataDescription);
+      }
     const auto status = this->Superclass::CoProcess(dataDescription);
     if (!status || this->ResultProducer == nullptr || this->ResultProducer[0] == '\0')
       {
@@ -99,29 +259,78 @@ protected:
     auto pxm = vtkSMProxyManager::GetProxyManager()->GetActiveSessionProxyManager();
     assert(pxm != nullptr);
 
-    auto producer = vtkSMSourceProxy::SafeDownCast(pxm->GetProxy("sources", this->ResultProducer));
-    if (!producer)
+    vtkSMSourceProxy* producer = nullptr;
+    if (this->ResultProducer != nullptr)
     {
-      SENSEI_ERROR("Failed to locate producer '" << this->ResultProducer << "'. "
-        "Please check the configuration or the Catalyst Python script for errors.");
-      return 0;
+      // find `ResultProducer` proxy and update it and get its data.
+      producer = vtkSMSourceProxy::SafeDownCast(pxm->GetProxy("sources", this->ResultProducer));
+      if (!producer)
+      {
+        SENSEI_ERROR("Failed to locate producer '" << this->ResultProducer << "'. "
+          "Please check the configuration or the Catalyst Python script for errors.");
+        return 0;
+      }
     }
-    producer->UpdatePipeline(dataDescription->GetTime());
-    if (vtkDataObject *result = vtkAlgorithm::SafeDownCast(producer->GetClientSideObject())->GetOutputDataObject(0))
+    else if (this->SteerableSource)
     {
-      svtkDataObject *sResult = SVTKUtils::SVTKObjectFactory::New(result);
-      this->ResultData.TakeReference(sResult->NewInstance());
+      producer = vtkSMSourceProxy::SafeDownCast(this->SteerableSource);
+    }
+
+    if (producer)
+    {
+      producer->UpdatePipeline(dataDescription->GetTime());
+      if (vtkDataObject *result = vtkAlgorithm::SafeDownCast(producer->GetClientSideObject())->GetOutputDataObject(0))
+      {
+        svtkDataObject *sResult = SVTKUtils::SVTKObjectFactory::New(result);
+        this->ResultData.TakeReference(sResult->NewInstance());
+      }
     }
     return 1;
   }
-
 
 private:
   CatalystScriptPipeline(const CatalystScriptPipeline&) = delete;
   void operator=(const CatalystScriptPipeline&) = delete;
 
+  // Creates steerable source proxy, if needed and then initializes it with
+  // current property values.
+  void InitializeSteerableSource(vtkCPDataDescription* dataDescription)
+  {
+    auto pxm = vtkSMProxyManager::GetProxyManager()->GetActiveSessionProxyManager();
+    assert(pxm != nullptr);
+
+    vtkSmartPointer<vtkSMProxy> source = this->SteerableSource;
+    if (source == nullptr)
+    {
+      source.TakeReference(pxm->NewProxy("sources", this->SteerableSourceType));
+      if (!source)
+      {
+        SENSEI_ERROR("Failed to create source for steering (sources, " << this->SteerableSourceType << ").");
+        // set type to null so we don't attempt this again.
+        this->SetSteerableSourceType(nullptr);
+        return;
+      }
+    }
+
+    if (!HandleSenseiInitializePropertiesWithMesh(source, dataDescription))
+    {
+      // set type to null so we don't attempt this again.
+      this->SteerableSource = nullptr;
+      this->SetSteerableSourceType(nullptr);
+      return;
+    }
+    source->UpdateVTKObjects();
+    if (this->SteerableSource == nullptr)
+    {
+      pxm->RegisterProxy("sources", "SteeringParameters", source);
+      this->SteerableSource = source;
+    }
+  }
+
   char* ResultProducer;
+  char* SteerableSourceType;
   char* ResultMesh;
+  vtkSmartPointer<vtkSMProxy> SteerableSource;
   svtkSmartPointer<svtkDataObject> ResultData;
 };
 
@@ -166,13 +375,18 @@ void CatalystAnalysisAdaptor::AddPipeline(vtkCPPipeline* pipeline)
 }
 
 //-----------------------------------------------------------------------------
-void CatalystAnalysisAdaptor::AddPythonScriptPipeline(const std::string &fileName,
-  const std::string& resultProducer, const std::string& resultMesh)
+void CatalystAnalysisAdaptor::AddPythonScriptPipeline(
+  const std::string& fileName,
+  const std::string& resultProducer,
+  const std::string& steerableSourceType,
+  const std::string& resultMesh)
 {
 #ifdef ENABLE_CATALYST_PYTHON
   vtkNew<sensei::CatalystScriptPipeline> pythonPipeline;
   pythonPipeline->SetResultProducer(!resultProducer.empty() ? resultProducer.c_str() : nullptr);
   pythonPipeline->SetResultMesh(!resultMesh.empty() ? resultMesh.c_str() : nullptr);
+  pythonPipeline->SetSteerableSourceType(
+    !steerableSourceType.empty() ? steerableSourceType.c_str() : nullptr);
   pythonPipeline->Initialize(fileName.c_str());
   this->AddPipeline(pythonPipeline.GetPointer());
 #else
@@ -181,6 +395,20 @@ void CatalystAnalysisAdaptor::AddPythonScriptPipeline(const std::string &fileNam
   SENSEI_ERROR("Failed to add Python script pipeline. "
     "Re-compile with ENABLE_CATALYST_PYTHON=ON")
 #endif
+}
+
+// ---------------------------------------------------------------------------
+void CatalystAnalysisAdaptor::AddPluginXML(const std::string& fileName)
+{
+  auto plmgr = vtkSMProxyManager::GetProxyManager()->GetPluginManager();
+  if (!plmgr->LoadLocalPlugin(fileName.c_str()))
+    {
+    SENSEI_ERROR("Failed to load plugin xml " << fileName.c_str());
+    }
+  else
+    {
+    SENSEI_STATUS("Catalyst plugin loaded: " << fileName.c_str());
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -286,7 +514,7 @@ int CatalystAnalysisAdaptor::SelectData(DataAdaptor *dataAdaptor,
           << meshName << "\"")
         }
 
-      // convert from VTK to VTK
+      // convert from SVTK to VTK
       vtkDataObject *vdobj = SVTKUtils::VTKObjectFactory::New(dobj);
 
       inDesc->SetGrid(vdobj);

--- a/sensei/CatalystAnalysisAdaptor.cxx
+++ b/sensei/CatalystAnalysisAdaptor.cxx
@@ -244,12 +244,14 @@ protected:
   int CoProcess(vtkCPDataDescription* dataDescription) override
   {
     this->ResultData = nullptr;
+
     if (this->SteerableSourceType != nullptr)
       {
       this->InitializeSteerableSource(dataDescription);
       }
+
     const auto status = this->Superclass::CoProcess(dataDescription);
-    if (!status || this->ResultProducer == nullptr || this->ResultProducer[0] == '\0')
+    if (!status)
       {
       return status;
       }
@@ -260,7 +262,7 @@ protected:
     assert(pxm != nullptr);
 
     vtkSMSourceProxy* producer = nullptr;
-    if (this->ResultProducer != nullptr)
+    if (this->ResultProducer != nullptr && this->ResultProducer[0] != '\0')
     {
       // find `ResultProducer` proxy and update it and get its data.
       producer = vtkSMSourceProxy::SafeDownCast(pxm->GetProxy("sources", this->ResultProducer));
@@ -283,6 +285,7 @@ protected:
       {
         svtkDataObject *sResult = SVTKUtils::SVTKObjectFactory::New(result);
         this->ResultData.TakeReference(sResult->NewInstance());
+        this->ResultData->ShallowCopy(sResult);
       }
     }
     return 1;

--- a/sensei/CatalystAnalysisAdaptor.h
+++ b/sensei/CatalystAnalysisAdaptor.h
@@ -46,12 +46,17 @@ public:
    * can be used to obtain such data.
    */
   virtual void AddPythonScriptPipeline(const std::string &fileName,
-    const std::string& resultProducer, const std::string& resultMesh);
+    const std::string& resultProducer, const std::string& steerableSourceType,
+    const std::string& resultMesh);
 
   /// Control how frequently the in situ processing occurs.
   int SetFrequency(unsigned int frequency);
 
   ///@}
+  /// @brief Add a plugin xml
+  ///
+  /// Adds a plugin XML which can add new proxy definitions.
+  virtual void AddPluginXML(const std::string& fileName);
 
   /// Invoke in situ processing using Catalyst
   bool Execute(DataAdaptor* data, DataAdaptor**) override;

--- a/sensei/ConfigurableAnalysis.cxx
+++ b/sensei/ConfigurableAnalysis.cxx
@@ -438,7 +438,7 @@ int ConfigurableAnalysis::InternalsType::AddAdios2(pugi::xml_node node)
     SENSEI_ERROR("Failed to configure the ADIOS2 adaptor from XML")
     return -1;
     }
-  
+
   unsigned int frequency = node.attribute("frequency").as_uint(0);
   adiosAdaptor->SetFrequency(frequency);
 
@@ -519,6 +519,12 @@ int ConfigurableAnalysis::InternalsType::AddCatalyst(pugi::xml_node node)
 
     this->TimeInitialization(this->CatalystAdaptor);
     this->Analyses.push_back(this->CatalystAdaptor);
+    }
+
+  // Add plugin xmls.
+  if (node.attribute("plugin_xml"))
+    {
+    this->CatalystAdaptor->AddPluginXML(node.attribute("plugin_xml").value());
     }
 
   // Add the pipelines
@@ -653,16 +659,18 @@ int ConfigurableAnalysis::InternalsType::AddCatalyst(pugi::xml_node node)
     if (node.attribute("filename"))
       {
       std::string fileName = node.attribute("filename").value();
-      std::string producer, mesh;
+      std::string producer, mesh, steerable_source_type;
+
       if (auto resultnode = node.child("result"))
       {
         producer = resultnode.attribute("producer").as_string();
+        steerable_source_type = resultnode.attribute("steerable_source_type").as_string();
         mesh = resultnode.attribute("mesh").as_string();
       }
       this->CatalystAdaptor->AddPythonScriptPipeline(fileName,
-          producer, mesh);
+          producer, steerable_source_type, mesh);
       }
-    
+
     unsigned int frequency = node.attribute("frequency").as_uint(0);
     this->CatalystAdaptor->SetFrequency(frequency);
 


### PR DESCRIPTION
This PR adds steering capabilities with Catalyst. A new `steerable_source_type` is added to the Catalyst SENSEI config specification, and infrastructure for sending data back through SENSEI to the simulation code is added. This work reinstates work done previously https://gitlab.kitware.com/sensei/sensei/-/merge_requests/225. 