### PR TITLE
libsim: Add missing symbol visibility for LibsimImageProperties

### DIFF
--- a/sensei/LibsimImageProperties.h
+++ b/sensei/LibsimImageProperties.h
@@ -1,12 +1,14 @@
 #ifndef sensei_LibsimImageProperties_h
 #define sensei_LibsimImageProperties_h
 
+#include "senseiConfig.h"
+
 #include <string>
 
 namespace sensei
 {
 
-class LibsimImageProperties
+class SENSEI_EXPORT LibsimImageProperties
 {
 public:
     LibsimImageProperties();


### PR DESCRIPTION
This resolved the following linker error:
```
/usr/bin/ld: ../../lib/libsensei.so: undefined reference to `sensei::LibsimImageProperties::LibsimImageProperties()'
/usr/bin/ld: ../../lib/libsensei.so: undefined reference to `sensei::LibsimImageProperties::SetHeight(int)'
/usr/bin/ld: ../../lib/libsensei.so: undefined reference to `sensei::LibsimImageProperties::~LibsimImageProperties()'
/usr/bin/ld: ../../lib/libsensei.so: undefined reference to `sensei::LibsimImageProperties::SetFilename(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ../../lib/libsensei.so: undefined reference to `sensei::LibsimImageProperties::SetWidth(int)'
collect2: error: ld returned 1 exit status
```