### PR TITLE
VTK always depends on CommonDataModel

### DIFF
--- a/CMake/vtk.cmake
+++ b/CMake/vtk.cmake
@@ -7,7 +7,7 @@ if (ENABLE_VTK_MPI OR ENABLE_VTK_IO OR ENABLE_VTK_MPI OR
 
   # lets build the list of modules for VTK pre-8.90 and post 8.90
   set(sensei_vtk_components_legacy)
-  set(sensei_vtk_components_modern)
+  set(sensei_vtk_components_modern CommonDataModel)
 
   if (ENABLE_VTK_MPI)
     list(APPEND sensei_vtk_components_legacy vtkParallelMPI)


### PR DESCRIPTION
When VTK_MPI is the only VTK option on, CommonDataModel is not
implicitly connected. Adding this so that it is always connected for
when VTK is enabled.