### PR TITLE
Fix typo in SWIG wrapper

### DIFF
--- a/sensei/DataAdaptor.i
+++ b/sensei/DataAdaptor.i
@@ -317,7 +317,7 @@ SENSEI_WRAP_DATA_ADAPTOR(DataAdaptor)
     return out;
   }
 }
-%ingnore sensei::##cname##::GetPartition;
+%ignore sensei::##cname##::GetPartition;
 %enddef
 
 PARTITIONER_API(Partitioner)


### PR DESCRIPTION
It seems like SWIG 4.0 accepts `%ingnore` but 4.1 does not (see https://gitlab.spack.io/spack/spack/-/pipelines/232372 from https://github.com/spack/spack/pull/34250).

```
sensei/DataAdaptor.i:323: Error: Unknown directive '%ingnore'
```