### PR TITLE
Fix CMake Paths to Python

### DIFF
--- a/CMake/SENSEIConfig.cmake.in
+++ b/CMake/SENSEIConfig.cmake.in
@@ -110,7 +110,7 @@ endif()
 include(senseiCore)
 
 if (ENABLE_PYTHON)
-  set(SENSEI_PYTHON_DIR "${CMAKE_CURRENT_LIST_DIR}/../../@SENSEI_PYTHON_DIR@")
+  set(SENSEI_PYTHON_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../@SENSEI_PYTHON_DIR@")
 
   include(sPython)
 

--- a/CMake/python.cmake
+++ b/CMake/python.cmake
@@ -41,7 +41,7 @@ if (ENABLE_PYTHON)
 
   # the destination of all SENSEI Python codes
   set(SENSEI_PYTHON_SITE
-    "${CMAKE_INSTALL_LIBDIR}/python-${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/"
+    "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/"
     CACHE STRING "Where Python modules are compiled and installed.")
 
   set(SENSEI_PYTHON_DIR "${SENSEI_PYTHON_SITE}/sensei/"


### PR DESCRIPTION
Resolves #93

I am unsure, if https://github.com/SENSEI-insitu/SENSEI/blob/develop/CMake/SENSEIConfig.cmake.in#L11 needs to be changed aswell

I also removed the dash in the path to the python directory. IMHO, it is quite uncommon to see a dash there and it should probably be removed.