### PR TITLE
Added scriptversion parameter to Catalyst analysis

### DIFF
--- a/sensei/CatalystAnalysisAdaptor.cxx
+++ b/sensei/CatalystAnalysisAdaptor.cxx
@@ -382,13 +382,14 @@ void CatalystAnalysisAdaptor::AddPythonScriptPipeline(
   const std::string& fileName,
   const std::string& resultProducer,
   const std::string& steerableSourceType,
-  const std::string& resultMesh)
+  const std::string& resultMesh,
+  int scriptVersion)
 {
 #ifdef ENABLE_CATALYST_PYTHON
 #if PARAVIEW_VERSION_MAJOR > 5 || (PARAVIEW_VERSION_MAJOR == 5 && PARAVIEW_VERSION_MINOR >= 9)
   // detect if we are given a Catalyst 1 or 2 script
   vtkSmartPointer<vtkCPPythonPipeline> pythonPipeline =
-    vtkCPPythonPipeline::CreateAndInitializePipeline(fileName.c_str());
+    vtkCPPythonPipeline::CreateAndInitializePipeline(fileName.c_str(), scriptVersion);
 
   // if we have a catalyst 1 script, we can create a pipeline with steering options
   if(auto catalyst1Pipeline = vtkCPPythonScriptPipeline::SafeDownCast(pythonPipeline))

--- a/sensei/CatalystAnalysisAdaptor.h
+++ b/sensei/CatalystAnalysisAdaptor.h
@@ -43,11 +43,12 @@ public:
   /** Adds a pipeline defined in a Catalyst python script. The Catalyst Python
    * script can be automatically generated using the ParaView GUI on a
    * representative dataset. The sensei::VTKPosthocIO and sensei::VTKAmrWriter
-   * can be used to obtain such data.
+   * can be used to obtain such data. If ParaView is unable to determine the
+   * version of the Script, if will default to the given version.
    */
-  virtual void AddPythonScriptPipeline(const std::string &fileName,
+  virtual void AddPythonScriptPipeline(const std::string& fileName,
     const std::string& resultProducer, const std::string& steerableSourceType,
-    const std::string& resultMesh);
+    const std::string& resultMesh, int scriptVersion = 1);
 
   /// Control how frequently the in situ processing occurs.
   int SetFrequency(unsigned int frequency);

--- a/sensei/ConfigurableAnalysis.cxx
+++ b/sensei/ConfigurableAnalysis.cxx
@@ -659,16 +659,18 @@ int ConfigurableAnalysis::InternalsType::AddCatalyst(pugi::xml_node node)
     if (node.attribute("filename"))
       {
       std::string fileName = node.attribute("filename").value();
-      std::string producer, mesh, steerable_source_type;
+      int scriptVersion = node.attribute("scriptversion").as_int(1);
 
+      std::string producer, mesh, steerable_source_type;
       if (auto resultnode = node.child("result"))
       {
         producer = resultnode.attribute("producer").as_string();
         steerable_source_type = resultnode.attribute("steerable_source_type").as_string();
         mesh = resultnode.attribute("mesh").as_string();
       }
+
       this->CatalystAdaptor->AddPythonScriptPipeline(fileName,
-          producer, steerable_source_type, mesh);
+          producer, steerable_source_type, mesh, scriptVersion);
       }
 
     unsigned int frequency = node.attribute("frequency").as_uint(0);


### PR DESCRIPTION
When using Catalyst Analysis, ParaView will try to determine the Version of the passed Catalyst script by checking the header of the file for a `# script-version: 2` line (see [here](https://gitlab.kitware.com/paraview/paraview/-/blob/master/Clients/PythonCatalyst/vtkCPPythonPipeline.cxx#L135)). If it does not exist, it will default to version 1.
With the `scriptversion="2"` attribute, the user can now overwrite that default version. While ParaView will always generate that line when exporting a Catalyst script, if you modify of create your own script and don't know about this mechanic you will run into errors.

Note that the `# script-version: 2` line in a Catalyst script will take precendence over this attribute and it merely presents a fallback version for Catalyst.