### PR TITLE
python rpath for SWIG'd sVTK library

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -30,7 +30,7 @@ if (ENABLE_PYTHON)
     if (APPLE)
       set_target_properties(senseiPython PROPERTIES INSTALL_RPATH "@loader_path/./")
     elseif(UNIX)
-      set_target_properties(senseiPython PROPERTIES INSTALL_RPATH "\$ORIGIN/./")
+      set_target_properties(senseiPython PROPERTIES INSTALL_RPATH "\$ORIGIN/;\$ORIGIN/../svtk/")
     endif()
 
   configure_file(sensei.py "${CMAKE_BINARY_DIR}/${SENSEI_PYTHON_DIR}/__init__.py"


### PR DESCRIPTION
set rpath to the svtk python bindings so that only sensei module need be found during import.