### PR TITLE
Correct typo in adios2_init version selection

### DIFF
--- a/sensei/ADIOS2AnalysisAdaptor.cxx
+++ b/sensei/ADIOS2AnalysisAdaptor.cxx
@@ -329,7 +329,7 @@ int ADIOS2AnalysisAdaptor::InitializeADIOS2()
     }
 
   // initialize adios2
-#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MINOR == 2 && ADIOS2_VERSION_MINOR >= 9)
+#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MAJOR == 2 && ADIOS2_VERSION_MINOR >= 9)
   // adios2_init()'s signature changed in version 2.9.0
   this->Adios = adios2_init(this->GetCommunicator());
 #else

--- a/sensei/ADIOS2Schema.cxx
+++ b/sensei/ADIOS2Schema.cxx
@@ -422,7 +422,7 @@ int InputStream::Initialize(MPI_Comm comm)
   sensei::TimeEvent<128> mark("senseiADIOS2::InputStream::Initialize");
 
   // initialize adios2
-#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MINOR == 2 && ADIOS2_VERSION_MINOR >= 9)
+#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MAJOR == 2 && ADIOS2_VERSION_MINOR >= 9)
   // adios2_init()'s signature changed in version 2.9.0
   this->Adios = adios2_init(comm);
 #else


### PR DESCRIPTION
Followup of #114 

In #114 we accidentally wrote:

```
#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MINOR == 2 && ADIOS2_VERSION_MINOR >= 9)
```
However, what we want is:
```
#if ADIOS2_VERSION_MAJOR > 2 || (ADIOS2_VERSION_MAJOR == 2 && ADIOS2_VERSION_MINOR >= 9)
```