### PR TITLE
CI: Remove Spack SENSEI build from test image

### DIFF
--- a/.github/ci/docker/ubuntu/configure-env.sh
+++ b/.github/ci/docker/ubuntu/configure-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . ${SPACK_ROOT}/share/spack/setup-env.sh
 
-SPACK_LMOD_ROOT=$(spack find --paths lmod | grep ^lmod@ | awk '{ print $2 }')
+SPACK_LMOD_ROOT=$(spack find --format {prefix} lmod)
 . ${SPACK_LMOD_ROOT}/lmod/lmod/init/bash
 
 if [[ -z ${SENSEI_ENV} ]]; then
@@ -19,4 +19,4 @@ spack env activate ${SENSEI_ENV}
 module use ${SPACK_ROOT}/share/spack/lmod/linux-ubuntu20.04-x86_64/Core
 module load openmpi ninja swig
 
-. ${SPACK_ROOT}/var/spack/environments/${SENSEI_ENV}/loads
+. /sensei/loads

--- a/.github/ci/docker/ubuntu/install-deps.sh
+++ b/.github/ci/docker/ubuntu/install-deps.sh
@@ -16,12 +16,17 @@ spack env activate ${SENSEI_ENV}
 # install
 N_THREADS=$(grep -c '^processor' /proc/cpuinfo)
 spack install -v --use-cache --no-check-signature -j ${N_THREADS}
-spack install -v --use-cache --no-check-signature -j ${N_THREADS} sensei
 
 # cleanup
 spack clean -a
 rm -rf /root/.spack /sensei/tmp /sensei/buildcache
 
-# load modules
+# generate modules
 spack module lmod refresh -y
-spack env loads -m lmod
+
+SENSEI_MODULE=$(spack module lmod find --full-path sensei)
+# write sensei module dependencies to file
+cat ${SENSEI_MODULE} | grep depends_on | awk -F'"' '{ print "module load " $2 }' > /sensei/loads
+
+# remove temporary sensei build from image
+spack uninstall -y sensei

--- a/.github/workflows/ecp-data-vis-sdk.yml
+++ b/.github/workflows/ecp-data-vis-sdk.yml
@@ -13,7 +13,7 @@ jobs:
       CMAKE_CONFIGURATION: ubuntu_ecp_catalyst
       LAUNCHER: /sensei/bin/launch-env.sh
     container:
-      image: ghcr.io/sensei-insitu/ci-ecp@sha256:ebbcd00f491ec8cd007d3fca8f43906d798bf3122cc60bc0bd9189788d8d5b41
+      image: ghcr.io/sensei-insitu/ci-ecp@sha256:f55ec48bb2e01738b52c71e8fb08d2cadbbf0a34f12db30f6809dae75b810e42
     steps:
     - uses: actions/checkout@v3
     - name: Initialize ccache


### PR DESCRIPTION
@kwryankrattiger Here's a fix for the spack environment with the CI. This environment doesn't have SENSEI installed but has the correct module loads for the test builds.